### PR TITLE
V2 aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 Releem releases
 ---
-Information about releases of the Releem Agent.
+Information about releases of the Releem.
+
+Releem 0.9.9, 2022-12-31
+- Added system metrics collection CPU, RAM, Swap, IOPS
+- Added Slow Log Graph in the Releem Customer Portal
+- Added CPU, IOPS, and Memory gauges for all users in the Releem Customer Portal
+- Added Docker integration container. Closes #108
+- Added Connection to MySQL via socket. Closes #117
+- Added All Servers page in the Releem Customer Portal
+- Improved Best Practices and Recommendations Block in the Releem Customer Portal
+- Improved Documentation
+- Fixed Installation with custome ip address. Closes #118
+- Fixed Releem Agent stopped after server reboot. Closes #122
+- Fixed During installation /etc/mysql/my.cnf was broke. Closes #126
+
+Releem 0.9.8, 2022-11-30
+- Added slow log queriest collection
+- Added Latency Graph in the Releem Customer Portal
+- Added collecting metrics from Performance Scheme
+- Improved Releem Agent installation process just in one command
+- Fixed output color. Closes #109
+- Fixed Exclude "MySQL client" information. Closes #45
+- Fixed Can't open error on CloudLinux. Closes #101
 
 Releem 0.9.7, 2022-10-31
 - Added installation logs collection.
@@ -21,7 +43,7 @@ Releem 0.9.5, 2022-08-31
 - Added Apply recommended MySQL configuration and rollback to previous configuration. Closes #63
 - Added Automatic update.
 - Added innodb_page_cleaners and innodb_purge_threads calculations.
-- Improved performance of Releem Agent minimize workload an run on servers with hundreds databases. Closes #30
+- Improved performance of Releem Agent minimize workload an run on servers with hundreds databases. Closes #30. Closes #58
 
 Releem 0.9.4, 2022-07-31
 - Added FreeBSD support. Closes #95

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM debian
 
-
 ARG DB_HOST
 ARG DB_PORT
 ARG DB_PASSWORD
@@ -8,6 +7,13 @@ ARG DB_USER
 
 ARG RELEEM_API_KEY
 ARG MEMORY_LIMIT
+
+ARG INSTANCE_TYPE
+ARG AWS_REGION
+ARG AWS_RDS_DB
+
+ARG RELEEM_ENV
+ARG RELEEM_DEBUG
 
 RUN apt update \
  && apt install -y \
@@ -18,12 +24,12 @@ RUN apt update \
  procps \
  iputils-ping
 
-
 RUN curl -L https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-`uname -s`-`uname -m` -o envsubst \
  && chmod +x envsubst \
  && mv envsubst /usr/local/bin
 
 WORKDIR /opt/releem
+RUN mkdir /opt/releem/conf
 
 COPY docker/ /docker/
 

--- a/docker/releem.conf.tpl
+++ b/docker/releem.conf.tpl
@@ -39,9 +39,29 @@ mysql_port="${DB_PORT:-3306}"
 mysql_restart_service=" /bin/systemctl restart mysql"
 
 # MysqlConfDir string `hcl:"mysql_cnf_dir"`
-# Defaults to 3600 seconds, the path to copy the recommended config.
+# The path to copy the recommended config.
 mysql_cnf_dir="/etc/mysql/releem.conf.d"
 
 # ReleemConfDir string `hcl:"releem_cnf_dir"`
-# Defaults to 3600 seconds, Releem Agent configuration path.
+# Releem Agent configuration path.
 releem_cnf_dir="/opt/releem/conf"
+
+# InstanceType string `hcl:"instance_type"`
+# Defaults to local, type of instance "local" or "aws/rds"
+instance_type="${INSTANCE_TYPE:-local}"
+
+# AwsRegion string `hcl:"aws_region"`
+# Defaults to us-east-1, AWS region for RDS
+aws_region="${AWS_REGION:-us-east-1}"
+
+# AwsRDSDB string `hcl:"aws_rds_db"`
+# RDS database name.
+aws_rds_db="${AWS_RDS_DB}"
+
+# Env string `hcl:"env"`
+# Releem Environment.
+env="${RELEEM_ENV:-prod}"
+
+# Debug string `hcl:"debug"`
+# Releem Debug messages
+debug=${RELEEM_DEBUG:-false}


### PR DESCRIPTION
Releem 0.9.9, 2022-12-31
- Added system metrics collection CPU, RAM, Swap, IOPS
- Added Slow Log Graph in the Releem Customer Portal
- Added CPU, IOPS, and Memory gauges for all users in the Releem Customer Portal
- Added Docker integration container. Closes #108 
- Added Connection to MySQL via socket. Closes #117 
- Added All Servers page in the Releem Customer Portal
- Improved Best Practices and Recommendations Block in the Releem Customer Portal
- Improved Documentation
- Fixed Installation with custome ip address. Closes #118 
- Fixed Releem Agent stopped after server reboot. Closes #122 
- Fixed During installation /etc/mysql/my.cnf was broke. Closes #126 

Releem 0.9.8, 2022-11-30
- Added slow log queriest collection
- Added Latency Graph in the Releem Customer Portal
- Added collecting metrics from Performance Scheme
- Improved Releem Agent installation process just in one command
- Fixed output color. Closes #109 
- Fixed Exclude "MySQL client" information. Closes #45 
- Fixed Can't open error on CloudLinux. Closes #101 